### PR TITLE
Allow overrding all SCSS variables

### DIFF
--- a/src/scss/variables.scss
+++ b/src/scss/variables.scss
@@ -7,18 +7,18 @@ $font-family:
     "Helvetica Neue", Arial, sans-serif, !default;
 
 // Constants
-$box-shadow-app: 0 0.2em 1.5em 0 rgba(0, 0, 0, 0.1), 0 0 1em 0 rgba(0, 0, 0, 0.02);
-$color-input-fields: #f8f8f8;
+$box-shadow-app: 0 0.2em 1.5em 0 rgba(0, 0, 0, 0.1), 0 0 1em 0 rgba(0, 0, 0, 0.02) !default;
+$color-input-fields: #f8f8f8 !default;
 
 // Colors
-$color-blue-active: #4285f4;
-$color-blue-hover: #4370f4;
+$color-blue-active: #4285f4 !default;
+$color-blue-hover: #4370f4 !default;
 
-$color-red-active: #f44250;
-$color-red-hover: #db3d49;
+$color-red-active: #f44250 !default;
+$color-red-hover: #db3d49 !default;
 
-$color-gray-light: #c4c4c4;
-$color-gray-default: #808080;
+$color-gray-light: #c4c4c4 !default;
+$color-gray-default: #808080 !default;
 
 $color-rainbow: linear-gradient(to bottom,
     hsl(0, 100%, 50%),
@@ -27,14 +27,14 @@ $color-rainbow: linear-gradient(to bottom,
     hsl(180, 100%, 50%),
     hsl(240, 100%, 50%),
     hsl(300, 100%, 50%),
-    hsl(360, 100%, 50%));
+    hsl(360, 100%, 50%)) !default;
 
 // Box shadows
-$box-shadow-small: 0 1px 2px 0 rgba(0, 0, 0, 0.2);
+$box-shadow-small: 0 1px 2px 0 rgba(0, 0, 0, 0.2) !default;
 
 // Border radius
-$border-radius-mid: 0.15em;
+$border-radius-mid: 0.15em !default;
 
 // Inline SVG muster
-$icon-transparency: url('data:image/svg+xml;utf8, <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2 2"><path fill="white" d="M1,0H2V1H1V0ZM0,1H1V2H0V1Z"/><path fill="gray" d="M0,0H1V1H0V0ZM1,1H2V2H1V1Z"/></svg>');
-$icon-x: url('data:image/svg+xml;utf8, <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 50 50" stroke="%2342445A" stroke-width="5px" stroke-linecap="round"><path d="M45,45L5,5"></path><path d="M45,5L5,45"></path></svg>')
+$icon-transparency: url('data:image/svg+xml;utf8, <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2 2"><path fill="white" d="M1,0H2V1H1V0ZM0,1H1V2H0V1Z"/><path fill="gray" d="M0,0H1V1H0V0ZM1,1H2V2H1V1Z"/></svg>') !default;
+$icon-x: url('data:image/svg+xml;utf8, <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 50 50" stroke="%2342445A" stroke-width="5px" stroke-linecap="round"><path d="M45,45L5,5"></path><path d="M45,5L5,45"></path></svg>') !default;


### PR DESCRIPTION
Currently one can only override the font variable. This PR allows to override all the other SCSS variables, too.