### PR TITLE
Added a 'verticalPosition' option

### DIFF
--- a/src/js/pickr.js
+++ b/src/js/pickr.js
@@ -28,6 +28,7 @@ class Pickr {
             default: 'fff',
             defaultRepresentation: 'HEX',
             position: 'middle',
+            verticalPosition: 'bottom',
             adjustableNumbers: true,
             showAlways: false,
             parent: undefined,
@@ -354,10 +355,19 @@ class Pickr {
         const as = app.style;
 
         // Check if picker is cuttet of from the top & bottom
-        if (ab.bottom > window.innerHeight) {
-            as.top = `${-(ab.height) - 5}px`;
-        } else if (bb.bottom + ab.height < window.innerHeight) {
-            as.top = `${bb.height + 5}px`;
+        // Check in different order depending of verticalPosition
+        if (this.options.verticalPosition == 'top') {
+            if (bb.bottom + ab.height < window.innerHeight) {
+                as.top = `${bb.height + 5}px`;
+            } else if (ab.bottom > window.innerHeight) {
+                as.top = `${-(ab.height) - 5}px`;
+            }
+        } else {
+            if (ab.bottom > window.innerHeight) {
+                as.top = `${-(ab.height) - 5}px`;
+            } else if (bb.bottom + ab.height < window.innerHeight) {
+                as.top = `${bb.height + 5}px`;
+            }
         }
 
         // Positioning picker on the x-axis


### PR DESCRIPTION
Added a 'verticalPosition' option to have the picker at the top by default instead of bottom.
(Value can be 'top' or 'bottom')