### PR TITLE
Remove `.pcr-app` on `destroyAndRemove()` and fix detached DOMs

### DIFF
--- a/src/js/pickr.js
+++ b/src/js/pickr.js
@@ -574,6 +574,15 @@ class Pickr {
         // Remove element
         const root = this._root.root;
         root.parentElement.removeChild(root);
+
+        // remove .pcr-app
+        const app = this._root.app;
+        app.parentElement.removeChild(app);
+
+        // There are references to various DOM elements stored in the pickr instance
+        // This cleans all of them to avoid detached DOMs
+        const pickr = this;
+        Object.keys(pickr).forEach(key => pickr[key] = null);
     }
 
     /**


### PR DESCRIPTION
Recent changes in pickr places the `.pcr-app` element as a child of `<body>` rather than its parent element. However, this element is not removed when `destroyAndRemove()` is called. This is especially pronounced in SPAs where pickr is used as a component and the `.pcr-app` element still exists even after the component itself has been destroyed. When multiple instances are used, there are numerous instances of these orphaned elements. A few event listeners were also still present.

This PR addresses these issues.

**Before**
Presence of `.pcr-app` after calling `destroyAndRemove()`
<img width="789" alt="pcr-app before" src="https://user-images.githubusercontent.com/7725225/56411423-498f6580-629e-11e9-9bc8-8589ef3f8df6.png">

**After**
`.pcr-app` is no longer present
<img width="860" alt="pcr-app after" src="https://user-images.githubusercontent.com/7725225/56411585-e18d4f00-629e-11e9-8c2a-d92687273dea.png">


**Before**
Detached DOMs after calling `destroyAndRemove( )`
<img width="1222" alt="detached DOMs before" src="https://user-images.githubusercontent.com/7725225/56411471-8196a880-629e-11e9-9c5f-2f44fded63d0.png">

**After**
Detached DOMs no longer present
<img width="1222" alt="No detached DOMs" src="https://user-images.githubusercontent.com/7725225/56411483-89eee380-629e-11e9-8d4c-8f5cde085fdf.png">


**Before**
Event Listeners still being present(the last two)
<img width="1219" alt="event listeners not cleaned up" src="https://user-images.githubusercontent.com/7725225/56411501-93784b80-629e-11e9-935a-9b24a3fea9f5.png">

**After**
Event Listeners cleaned up(what remains seems to be from webpack's live reload server)
<img width="1220" alt="event listeners cleaned up" src="https://user-images.githubusercontent.com/7725225/56411528-af7bed00-629e-11e9-8831-61c23d603403.png">
