### PR TITLE
on cancel click , color fix

### DIFF
--- a/src/js/pickr.js
+++ b/src/js/pickr.js
@@ -340,9 +340,9 @@ class Pickr {
             _.on([
                 _root.interaction.cancel,
                 _root.preview.lastColor
-            ], 'click', () => {
-                this._emit('cancel', this);
+            ], 'click', () => {                
                 this.setHSVA(...(this._lastColor || this._color).toHSVA(), true);
+                this._emit('cancel', this);
             }),
 
             // Save color


### PR DESCRIPTION
On cancel click ,

1.  first set ```setHSVA```
1.  then emit ```cancel```

now when user does **this** (see blow) , he will get correct color
```js
  .on("cancel", function(instance) {
     current_color = instance
       .getColor()
       .toHEXA()
       .toString();
     console.log("cancel", current_color);      
   })
```