### PR TITLE
Change the button strings type to `string`

### DIFF
--- a/types/pickr.d.ts
+++ b/types/pickr.d.ts
@@ -85,9 +85,9 @@ declare namespace Pickr {
         },
 
         strings?: {
-            save?: 'Save',
-            clear?: 'Clear',
-            cancel?: 'Cancel'
+            save?: string,
+            clear?: string,
+            cancel?: string
         }
     }
 


### PR DESCRIPTION
Cannot change button strings when using TypeScript.

```js
(property) Pickr.Options.strings?: {
    save?: "Save" | undefined;
    clear?: "Clear" | undefined;
    cancel?: "Cancel" | undefined;
} | undefined
```