### PR TITLE
Fix memory leak from event listeners not being removed

### DIFF
--- a/src/js/libs/moveable.js
+++ b/src/js/libs/moveable.js
@@ -132,12 +132,11 @@ export default function Moveable(opt) {
 
         destroy() {
             const {options, _tapstart} = that;
+            _.off(document, ['keydown', 'keyup'], _keyboard);
             _.off([options.wrapper, options.element], 'mousedown', _tapstart);
             _.off([options.wrapper, options.element], 'touchstart', _tapstart, {
                 passive: false
             });
-            _.off(document, 'keydown', _keyboard);
-            _.off(document, 'keyup', _keyboard);
         }
     };
 

--- a/src/js/libs/moveable.js
+++ b/src/js/libs/moveable.js
@@ -136,6 +136,8 @@ export default function Moveable(opt) {
             _.off([options.wrapper, options.element], 'touchstart', _tapstart, {
                 passive: false
             });
+            _.off(document, 'keydown', _keyboard);
+            _.off(document, 'keyup', _keyboard);
         }
     };
 


### PR DESCRIPTION
Events registered on `document` were note being removed on destroy, leading to memory leaks when creating and destroying instances of Pickr again and again.