### PR TITLE
Readme: Options/comparison: Rephrase doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,10 @@ const pickr = new Pickr({
     // Precision of output string (only effective if components.interaction.input is true)
     outputPrecision: 0,
 
-    // If set to false it would directly apply the selected color on the button and preview.
+    // Defines change/save behavior:
+    // - to keep current color in place until Save is pressed, set to `true`,
+    // - to apply color to button and preview (save) in sync with each change
+    //   (from picker or palette), set to `false`.
     comparison: true,
 
     // Default color. If you're using a named color such as red, white ... set


### PR DESCRIPTION
Motivation: I had a hard time finding the option, and even did a Cmd-F for "save" and couldn't find this ;) Fortunately I could parse through #25 to find it!

Seeing `save: false` is default, it might make sense to think through sensible defaults for this option. I don't know the full functionality of the library, but I can say that using it without swatches and no save button doesn't really make sense for defaulting to `comparison: true`. I was confused for a moment!