### PR TITLE
Rethinking minimal example and defaults (RFC)

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,12 +122,20 @@ jsdelivr:
 Be sure to load the `pickr.min.js` (or the es5 version) **after** `pickr.min.css`. Moreover the `script` tag doesn't work with the `defer` attribute.
 
 ## Usage
+With minimal configuration:
+
 ```javascript
-// Simple example, see optional options for more configuration.
+const pickr = Pickr.create()
+```
+
+Simple example indicating defaults: (see *Options* section for more)
+
+```javascript
 const pickr = Pickr.create({
-    el: '.color-picker',
+    el: 'color-picker',
     theme: 'classic', // or 'monolith', or 'nano'
 
+    // (optional)
     swatches: [
         'rgba(244, 67, 54, 1)',
         'rgba(233, 30, 99, 0.95)',
@@ -145,12 +153,12 @@ const pickr = Pickr.create({
         'rgba(255, 193, 7, 1)'
     ],
 
+    // Specifying 'components' will override all defaults
     components: {
-
         // Main components
         preview: true,
-        opacity: true,
         hue: true,
+        opacity: false,
 
         // Input / output Options
         interaction: {

--- a/README.md
+++ b/README.md
@@ -365,6 +365,7 @@ An alternative would be to provide the target-element itself as `el`.
 ## The HSVaColor object
 As default color representation is hsva (`hue`, `saturation`, `value` and `alpha`) used, but you can also convert it to other formats as listed below.
 
+* hsva.toString() - _Alias for `toHSLA().toString()`._
 * hsva.toHSVA() _- Converts the object to a hsva array._
 * hsva.toHSLA() _- Converts the object to a hsla array._
 * hsva.toRGBA() _- Converts the object to a rgba array._
@@ -372,7 +373,7 @@ As default color representation is hsva (`hue`, `saturation`, `value` and `alpha
 * hsva.toCMYK() _- Converts the object to a cmyk array._
 * hsva.clone() _- Clones the color object._
 
-The `toString()` is overridden so you can get a color representation string.
+Calling `toString()` on each of these will return a color representation string.
 
 ```javascript
 hsva.toRGBA(); // Returns [r, g, b, a]

--- a/README.md
+++ b/README.md
@@ -104,6 +104,11 @@ const pickr = Pickr.create({
         'rgba(255, 193, 7, 1)'
     ],
 
+    // either
+    save: true,
+    // or
+    comparison: false,
+
     // Specifying 'components' will override all defaults
     components: {
         // Main components

--- a/README.md
+++ b/README.md
@@ -72,55 +72,6 @@
 
 > Nano uses css-grid thus it won't work in older browsers.
 
-## Getting Started
-### Node
-Note: The readme is always up-to-date with the latest commit. See [Releases](https://github.com/Simonwep/pickr/releases) for installation instructions regarding to the latest version.
-
-Install via npm:
-```shell
-$ npm install @simonwep/pickr
-```
-
-Install via yarn:
-```shell
-$ yarn add @simonwep/pickr
-```
-
-Include code and style:
-```js
-
-// One of the following themes
-import '@simonwep/pickr/dist/themes/classic.min.css';   // 'classic' theme
-import '@simonwep/pickr/dist/themes/monolith.min.css';  // 'monolith' theme
-import '@simonwep/pickr/dist/themes/nano.min.css';      // 'nano' theme
-
-// Modern or es5 bundle (pay attention to the note below!)
-import Pickr from '@simonwep/pickr';
-import Pickr from '@simonwep/pickr/dist/pickr.es5.min';
-```
----
-
-> Attention: The es5-bundle (e.g. legacy version) is quite big (around a triple of the modern bundle).
-> Please take into consideration to use the modern version and add polyfills later to your final bundle!
-> (Or better: give a hint to users that they should use the latest browsers)
-
-### Browser
-
-jsdelivr:
-```html
-
-<!-- One of the following themes -->
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@simonwep/pickr/dist/themes/classic.min.css"/> <!-- 'classic' theme -->
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@simonwep/pickr/dist/themes/monolith.min.css"/> <!-- 'monolith' theme -->
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@simonwep/pickr/dist/themes/nano.min.css"/> <!-- 'nano' theme -->
-
-<!-- Modern or es5 bundle -->
-<script src="https://cdn.jsdelivr.net/npm/@simonwep/pickr/dist/pickr.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/@simonwep/pickr/dist/pickr.es5.min.js"></script>
-```
-
-Be sure to load the `pickr.min.js` (or the es5 version) **after** `pickr.min.css`. Moreover the `script` tag doesn't work with the `defer` attribute.
-
 ## Usage
 With minimal configuration:
 
@@ -176,6 +127,55 @@ const pickr = Pickr.create({
 ```
 
 > You can find more examples [here](EXAMPLES.md).
+
+## Install
+### Node
+Note: The readme is always up-to-date with the latest commit. See [Releases](https://github.com/Simonwep/pickr/releases) for installation instructions regarding to the latest version.
+
+Install via npm:
+```shell
+$ npm install @simonwep/pickr
+```
+
+Install via yarn:
+```shell
+$ yarn add @simonwep/pickr
+```
+
+Include code and style:
+```js
+
+// One of the following themes
+import '@simonwep/pickr/dist/themes/classic.min.css';   // 'classic' theme
+import '@simonwep/pickr/dist/themes/monolith.min.css';  // 'monolith' theme
+import '@simonwep/pickr/dist/themes/nano.min.css';      // 'nano' theme
+
+// Modern or es5 bundle (pay attention to the note below!)
+import Pickr from '@simonwep/pickr';
+import Pickr from '@simonwep/pickr/dist/pickr.es5.min';
+```
+---
+
+> Attention: The es5-bundle (e.g. legacy version) is quite big (around a triple of the modern bundle).
+> Please take into consideration to use the modern version and add polyfills later to your final bundle!
+> (Or better: give a hint to users that they should use the latest browsers)
+
+### Browser
+
+jsdelivr:
+```html
+
+<!-- One of the following themes -->
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@simonwep/pickr/dist/themes/classic.min.css"/> <!-- 'classic' theme -->
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@simonwep/pickr/dist/themes/monolith.min.css"/> <!-- 'monolith' theme -->
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@simonwep/pickr/dist/themes/nano.min.css"/> <!-- 'nano' theme -->
+
+<!-- Modern or es5 bundle -->
+<script src="https://cdn.jsdelivr.net/npm/@simonwep/pickr/dist/pickr.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@simonwep/pickr/dist/pickr.es5.min.js"></script>
+```
+
+Be sure to load the `pickr.min.js` (or the es5 version) **after** `pickr.min.css`. Moreover the `script` tag doesn't work with the `defer` attribute.
 
 ## Events
 Since version `0.4.x` Pickr is event-driven. Use the `on(event, cb)` and `off(event, cb)` functions to bind / unbind eventlistener.

--- a/index.html
+++ b/index.html
@@ -64,9 +64,35 @@
 </header>
 
 <main>
-    <div class="theme-container"></div>
-    <div class="pickr-container"></div>
-    <p>(Tap it)</p>
+    <section class="demo">
+      <div class="theme-container"></div>
+
+      <div class="pickr-container">
+      </div>
+
+      <p class="hint">(Tap it)</p>
+    </section>
+
+    <section class="usage">
+      <h2>Usage</h2>
+      <pre><code class="language-js">
+const pickr = new Pickr({
+  // el: 'color-picker',
+  // theme: 'classic',
+  // components: {
+  //   hue: true,
+  //   preview: true,
+  // }
+})
+      </code></pre>
+
+      <p class="hint">
+        Comments indicate defaults.
+      </p>
+
+      <p><a href="https://github.com/Simonwep/pickr">Readme &rarr;</a></p>
+    </section>
+
 </main>
 
 <script src="dist/pickr.es5.min.js"></script>

--- a/index.html
+++ b/index.html
@@ -68,6 +68,7 @@
       <div class="theme-container"></div>
 
       <div class="pickr-container">
+        <color-picker></color-picker>
       </div>
 
       <p class="hint">(Tap it)</p>
@@ -75,10 +76,23 @@
 
     <section class="usage">
       <h2>Usage</h2>
+
+      <p>As an HTML custom element:</p>
+      <pre><code class="language-html">
+&lt;color-picker&gt;&lt;/color-picker&gt;
+      </code></pre>
+
+      <p class="hint">
+        To customize the invocation, simply use the Javascript approach below,
+        using <code>color-picker</code> as the selector ('el').
+      </p>
+
+      <p>or use the classic Javascript approach:</p>
       <pre><code class="language-js">
 const pickr = new Pickr({
   // el: 'color-picker',
   // theme: 'classic',
+  // comparison: true,
   // components: {
   //   hue: true,
   //   preview: true,

--- a/src/js/pickr.js
+++ b/src/js/pickr.js
@@ -52,7 +52,11 @@ class Pickr {
             lockOpacity: false,
             autoReposition: true,
             container: 'body',
+
+            // If 'components' present, is overridden by the shallow merge
             components: {
+                preview: true,
+                hue: true,
                 interaction: {}
             },
 

--- a/src/js/utils/hsvacolor.js
+++ b/src/js/utils/hsvacolor.js
@@ -12,6 +12,10 @@ export function HSVaColor(h = 0, s = 0, v = 0, a = 1) {
     const that = {
         h, s, v, a,
 
+        toString() {
+            return that.toHSLA().toString();
+        },
+
         toHSVA() {
             const hsva = [that.h, that.s, that.v, that.a];
             hsva.toString = mapper(hsva, arr => `hsva(${arr[0]}, ${arr[1]}%, ${arr[2]}%, ${that.a})`);

--- a/st/script.js
+++ b/st/script.js
@@ -108,7 +108,7 @@ for (const [theme, config] of themes) {
     buttons.push(button);
 
     button.addEventListener('click', () => {
-        const el = document.createElement('p');
+        const el = document.createElement('color-picker');
         pickrContainer.appendChild(el);
 
         // Delete previous instance

--- a/st/styles.css
+++ b/st/styles.css
@@ -17,6 +17,22 @@ body {
     background: linear-gradient(to bottom, #f0f8ff, #ffffff);
 }
 
+h2 {
+  margin-bottom: 0.5em;
+}
+
+p {
+  margin: 0.7em 0;
+}
+
+pre {
+  background: hsl(211.1, 50%, 94.7%);
+  border-radius: 3px;
+  border: 1px solid hsl(213.1, 24.4%, 76.7%);
+  color: hsl(211.1, 32%, 37%);
+  padding: 0 1em;
+}
+
 body header {
     position: relative;
     padding: 10vh 0;
@@ -50,7 +66,15 @@ body header a:hover {
 }
 
 body main {
-    margin: 0 auto;
+    max-width: 30em;
+    margin: 0 auto 3em;
+}
+
+section + section{
+  margin-top: 4em;
+}
+
+section.demo {
     display: flex;
     align-items: center;
     flex-direction: column;
@@ -82,11 +106,11 @@ body main {
     color: #36425b;
 }
 
-.pickr-container {
+color-picker {
     margin-top: 2em;
 }
 
-main > p {
+p.hint {
     margin-top: 0.35em;
     font-size: 0.75em;
     font-weight: 500;
@@ -123,26 +147,5 @@ main > p {
         padding: 1em 2em;
         font-weight: 600;
         font-size: 1.05em;
-    }
-
-    main > section {
-        min-width: 90%;
-    }
-
-    main > section h2 {
-        font-size: 1em;
-    }
-
-    main > section pre {
-        font-size: 0.9em;
-    }
-
-    main section.demo .hint svg {
-        height: 1.2em;
-    }
-
-    main section.demo .hint span {
-        transform: translate3d(-3em, -1.4em, 0);
-        font-size: 0.6em;
     }
 }


### PR DESCRIPTION
I always appreciate when a library takes time to consider sensible defaults without needing configuration, allowing me to start quickly.

I would suggest, first off, to document the most minimal case that this plugin can be used. This is what this PR attempts. We could then tack on changing defaults (and schedule for minor/major revisions).

It would:
* put default essential options in comment
* include "required" (or strongly encouraged) options in the example

Some thoughts about the defaults:
* A sensible default for `el` would be a nice-to-have. This could be `.pickr`, `.js-pickr`, etc. Although specifying the element is not a big hassle. (Currently, no `el` throws an error)
* Documenting the default for `theme`, currently `classic`. See note below.
* Indicating a sensible path for `save` and `comparison`. See #195.
* Indicating a component needs to be set or choosing defaults. In my opinion, hue and preview are good picks.

About the theme: I wonder whether it's feasible to automatically detect the theme. eg using `getComputedStyle` on ready, and setting `.dummy-selector{ z-index: 1 }` (where z-index is the theme ID)

What do you think?