### PR TITLE
fix: webpack 5 deprecation warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "webpack-cleanup-plugin": "^0.5.1",
         "webpack-cli": "^4.7.2",
         "webpack-dev-server": "^4.0.0-beta.3",
-        "webpack-fix-style-only-entries": "^0.6.1"
+        "webpack-remove-empty-scripts":"1.0.1"
     },
     "homepage": "https://github.com/Simonwep/pickr#readme",
     "repository": {

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,4 +1,4 @@
-const FixStyleOnlyEntriesPlugin = require('webpack-fix-style-only-entries');
+const RemoveEmptyScriptsPlugin = require('webpack-remove-empty-scripts');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
 const {version} = require('../package');
@@ -48,7 +48,7 @@ const path = require('path');
 
         plugins: [
             banner,
-            new FixStyleOnlyEntriesPlugin(),
+            new RemoveEmptyScriptsPlugin(),
             new MiniCssExtractPlugin({
                 filename: '[name].min.css'
             })


### PR DESCRIPTION
Hello Simon,


during Webpack process via `npm run build` are displayed deprecation warnings:

```
[DEP_WEBPACK_CHUNK_HAS_ENTRY_MODULE] DeprecationWarning: Chunk.hasEntryModule: Use new ChunkGraph API
[DEP_WEBPACK_CHUNK_ENTRY_MODULE] DeprecationWarning: Chunk.entryModule: Use new ChunkGraph API
[DEP_WEBPACK_MODULE_INDEX] DeprecationWarning: Module.index: Use new ModuleGraph API
```

This happens because is used outdated the [webpack-fix-style-only-entries](https://github.com/fqborges/webpack-fix-style-only-entries).

> **Warning**
> 
> This plugin is not compatible with webpack 5. There is a fork here that is compatible: [webpack-remove-empty-scripts](https://github.com/webdiscus/webpack-remove-empty-scripts)

This PR replace the `webpack-fix-style-only-entries` with `webpack-remove-empty-scripts` package.