### PR TITLE
Extension of Slider type

### DIFF
--- a/types/pickr.d.ts
+++ b/types/pickr.d.ts
@@ -166,7 +166,7 @@ declare namespace Pickr {
         'HSLA' |
         'CMYK';
 
-    type Slider = 'v' | 'h';
+    type Slider = 'v' | 'h' | 'vh' | 'hv';
 }
 
 export default Pickr;


### PR DESCRIPTION
Typescript swears at 'vh' and 'hv' if you want to change the direction of the sliders.

`Type '"hv"' is not assignable to type 'Slider | undefined'.`